### PR TITLE
Allow empty request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <h1 align="center">Actio</h1>
 <h4 align="center">The Node.js framework for monoliths and microservices.</h4>
 <p align="center">
-<img src="https://github.com/crufters/actio/actions/workflows/build.yaml/badge.svg" /> <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL_v3-blue.svg" alt="License: AGPL v3"/></a> <img src="https://img.shields.io/badge/semver-0.2.18-yellow" />
+<img src="https://github.com/crufters/actio/actions/workflows/build.yaml/badge.svg" /> <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL_v3-blue.svg" alt="License: AGPL v3"/></a> <img src="https://img.shields.io/badge/semver-0.2.20-yellow" />
 </p>
 
 Actio is a modern, batteries included Node.js (Typescript) framework for your backend applications.

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@crufters/actio": "^0.2.17",
+        "@crufters/actio": "^0.2.20",
         "@types/express": "^4.17.17",
         "dotenv": "^16.0.3",
         "express": "^4.18.2"
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@crufters/actio": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@crufters/actio/-/actio-0.2.18.tgz",
-      "integrity": "sha512-zf5FQSatz3/eCGaWnoVXCrX+ZaSV9p5fGk+6CskVmdBaAM3HzC88oTeeyRDS3pDpNq8GJqNi+NjHbLk4D1WAYw==",
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@crufters/actio/-/actio-0.2.20.tgz",
+      "integrity": "sha512-gGuey3RdigYeGMNUixEHqO8wBViVa99634VR+YQmt+yYgug2vLqP5FxxtzYYuVF7wdgv5l5lDlRIK0fdGqNBBA==",
       "dependencies": {
         "@google-cloud/storage": "^6.7.0",
         "@sendgrid/mail": "^7.7.0",
@@ -3099,9 +3099,9 @@
   },
   "dependencies": {
     "@crufters/actio": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@crufters/actio/-/actio-0.2.18.tgz",
-      "integrity": "sha512-zf5FQSatz3/eCGaWnoVXCrX+ZaSV9p5fGk+6CskVmdBaAM3HzC88oTeeyRDS3pDpNq8GJqNi+NjHbLk4D1WAYw==",
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@crufters/actio/-/actio-0.2.20.tgz",
+      "integrity": "sha512-gGuey3RdigYeGMNUixEHqO8wBViVa99634VR+YQmt+yYgug2vLqP5FxxtzYYuVF7wdgv5l5lDlRIK0fdGqNBBA==",
       "requires": {
         "@google-cloud/storage": "^6.7.0",
         "@sendgrid/mail": "^7.7.0",

--- a/examples/package.json
+++ b/examples/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@crufters/actio": "^0.2.17",
+    "@crufters/actio": "^0.2.20",
     "@types/express": "^4.17.17",
     "dotenv": "^16.0.3",
     "express": "^4.18.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crufters/actio",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "type": "module",
   "description": "Actio is a lightweight, batteries included Node.js framework for your backend applications.",
   "main": "lib/index.js",

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@jest/globals";
+
+import { createApp } from "./registrator.js";
+import { Service } from "./reflect.js";
+import { default as request } from "supertest";
+import _ from "lodash";
+
+@Service()
+class InvalidJSON {
+  constructor() {}
+
+  async hey() {
+    return 1;
+  }
+}
+
+test("invalid json", async () => {
+  let appA = createApp([InvalidJSON]);
+
+  let response = await request(appA).post("/InvalidJSON/hey").send(null);
+  expect(response.status).toBe(200);
+  expect(response.body).toEqual(1);
+});

--- a/src/registrator.ts
+++ b/src/registrator.ts
@@ -167,6 +167,15 @@ export class Registrator {
     } else {
       // @todo maybe remove this and always parse
       let req;
+    
+      // support empty body
+      if (
+        request.body === undefined ||
+        request.body === null ||
+        request.body === ""
+      ) {
+        request.body = "{}";
+      }
       try {
         req =
           typeof request.body === "string"


### PR DESCRIPTION
JSON endpoint handling threw an `invalid json` error when called with empty request body.
This PR fixes that by falling back to `{}` when the request body is empty.