### PR TITLE
Export default auth config + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <h1 align="center">Actio</h1>
 <h4 align="center">The Node.js framework for monoliths and microservices.</h4>
 <p align="center">
-<img src="https://github.com/crufters/actio/actions/workflows/build.yaml/badge.svg" /> <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL_v3-blue.svg" alt="License: AGPL v3"/></a> <img src="https://img.shields.io/badge/semver-0.2.32-yellow" />
+<img src="https://github.com/crufters/actio/actions/workflows/build.yaml/badge.svg" /> <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL_v3-blue.svg" alt="License: AGPL v3"/></a> <img src="https://img.shields.io/badge/semver-0.2.33-yellow" />
 </p>
 
 Actio is a modern, batteries included Node.js (Typescript) framework for your backend applications.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,20 +5,23 @@ This folder does not aim to be in depth for the topics covered here - that will 
 Instead it aims to read more like a tutorial.
 
 <!-- vscode-markdown-toc -->
-* 1. [How to run these examples](#Howtoruntheseexamples)
-* 2. [How to create a new project from scratch](#Howtocreateanewprojectfromscratch)
-	* 2.1. [Initialize](#Initialize)
-	* 2.2. [tsconfig.ts](#tsconfig.ts)
-	* 2.3. [package.json](#package.json)
-	* 2.4. [index.ts](#index.ts)
-	* 2.5. [Compile and run](#Compileandrun)
-	* 2.6. [cURL](#cURL)
-* 3. [Authentication](#Authentication)
-* 4. [Endpoint decorators](#Endpointdecorators)
-	* 4.1. [Unexposed](#Unexposed)
-		* 4.1.1. [Why Unexposed is important](#WhyUnexposedisimportant)
-	* 4.2. [Raw](#Raw)
-* 5. [Testing](#Testing)
+
+- 1. [How to run these examples](#Howtoruntheseexamples)
+- 2. [How to create a new project from scratch](#Howtocreateanewprojectfromscratch)
+  - 2.1. [Initialize](#Initialize)
+  - 2.2. [tsconfig.ts](#tsconfig.ts)
+  - 2.3. [package.json](#package.json)
+  - 2.4. [index.ts](#index.ts)
+  - 2.5. [Compile and run](#Compileandrun)
+  - 2.6. [cURL](#cURL)
+- 3. [Authentication](#Authentication)
+- 4. [Endpoint decorators](#Endpointdecorators)
+  - 4.1. [Unexposed](#Unexposed)
+    - 4.1.1. [Why Unexposed is important](#WhyUnexposedisimportant)
+  - 4.2. [Raw](#Raw)
+- 5. [Testing](#Testing)
+  - 5.1. [Anatomy of a test](#Anatomyofatest)
+  - 5.2. [Misc](#Misc)
 
 <!-- vscode-markdown-toc-config
 	numbering=true
@@ -26,7 +29,7 @@ Instead it aims to read more like a tutorial.
 	/vscode-markdown-toc-config -->
 <!-- /vscode-markdown-toc -->
 
-##  1. <a name='Howtoruntheseexamples'></a>How to run these examples
+## 1. <a name='Howtoruntheseexamples'></a>How to run these examples
 
 Run
 
@@ -45,9 +48,9 @@ npx ts-node --esm ./basic.ts
 
 Replace `basic.ts` with the file you want to run.
 
-##  2. <a name='Howtocreateanewprojectfromscratch'></a>How to create a new project from scratch
+## 2. <a name='Howtocreateanewprojectfromscratch'></a>How to create a new project from scratch
 
-###  2.1. <a name='Initialize'></a>Initialize
+### 2.1. <a name='Initialize'></a>Initialize
 
 Run the following in your terminal:
 
@@ -61,7 +64,7 @@ npx tsc --init
 touch index.ts
 ```
 
-###  2.2. <a name='tsconfig.ts'></a>tsconfig.ts
+### 2.2. <a name='tsconfig.ts'></a>tsconfig.ts
 
 Make sure your `tsconfig.ts` looks something like this
 
@@ -82,11 +85,11 @@ Make sure your `tsconfig.ts` looks something like this
 }
 ```
 
-###  2.3. <a name='package.json'></a>package.json
+### 2.3. <a name='package.json'></a>package.json
 
 and make sure the `package.json` has `"type": "module"`.
 
-###  2.4. <a name='index.ts'></a>index.ts
+### 2.4. <a name='index.ts'></a>index.ts
 
 Create a basic service in index.ts
 
@@ -116,7 +119,7 @@ class MyService implements Servicelike {
 startServer([MyService]);
 ```
 
-###  2.5. <a name='Compileandrun'></a>Compile and run
+### 2.5. <a name='Compileandrun'></a>Compile and run
 
 Compile and run your project from project root:
 
@@ -128,7 +131,7 @@ Should output `Server is listening on port 8080`.
 
 Now do a curl:
 
-###  2.6. <a name='cURL'></a>cURL
+### 2.6. <a name='cURL'></a>cURL
 
 ```sh
 curl -XPOST -d '{"name":"Johnny"}' 127.0.0.1:8080/MyService/myEndpoint
@@ -140,7 +143,7 @@ The output should be:
 {"hi":"Johnny"}
 ```
 
-##  3. <a name='Authentication'></a>Authentication
+## 3. <a name='Authentication'></a>Authentication
 
 Let's run the `auth.ts` example and curl it:
 
@@ -210,9 +213,9 @@ As you can see we successfully called the `AuthenticationService` from our own a
 
 Note that the current pattern of calling the AuthenticationService in most endpoints is prone to fan-out but a JWT implementation is being considered for those who prefer to avoid that.
 
-##  4. <a name='Endpointdecorators'></a>Endpoint decorators
+## 4. <a name='Endpointdecorators'></a>Endpoint decorators
 
-###  4.1. <a name='Unexposed'></a>Unexposed
+### 4.1. <a name='Unexposed'></a>Unexposed
 
 You can use the `@Unexposed` decorator to mark a method as one that should not be exposed as a HTTP endpoint.
 
@@ -266,13 +269,13 @@ MyService/myEndpoint 4ms 200
 MyService/notMyEndpoint 1ms 404 Error { message: 'endpoint not found' }
 ```
 
-####  4.1.1. <a name='WhyUnexposedisimportant'></a>Why Unexposed is important
+#### 4.1.1. <a name='WhyUnexposedisimportant'></a>Why Unexposed is important
 
 The `@Unexposed` decorator is supremely important because it enables us to build endpoints only available to other services but not available to end users at the API gateway level.
 
 @todo: For monoliths the current implementation is fine but for a microservices setup we need to build out a service to service call mechanism driven by this decorator.
 
-###  4.2. <a name='Raw'></a>Raw
+### 4.2. <a name='Raw'></a>Raw
 
 Class methods get turned into JSON expecting HTTP endpoints by Actio. This works fine for most use cases but sometimes we need access to the underlying HTTP request and response types. A prime example of that is the `FileService`:
 
@@ -290,7 +293,176 @@ Class methods get turned into JSON expecting HTTP endpoints by Actio. This works
 
 The prefix if `http` in the method name is not mandatory.
 
-##  5. <a name='Testing'></a>Testing
+## 5. <a name='Testing'></a>Testing
+
+### 5.1. <a name='Anatomyofatest'></a>Anatomy of a test
+
+Actio's dependency injection makes it a breeze to test your services. Let's build a simple key value service and test it.
+For ease of reading we will put the service and the test in the same file:
+
+```ts
+import { test, expect, describe } from "@jest/globals";
+import { nanoid } from "nanoid";
+import { Service, Injector } from "@crufters/actio";
+import { DataSource, Entity, PrimaryColumn, Column } from "typeorm";
+
+@Entity()
+export class KV {
+  @PrimaryColumn()
+  id?: string;
+
+  @Column()
+  value?: string;
+}
+
+interface SetRequest {
+  key?: string;
+  value?: string;
+}
+
+interface GetRequest {
+  key?: string;
+}
+
+interface GetResponse {
+  value?: string;
+}
+
+@Service()
+class MyService {
+  meta = {
+    typeorm: {
+      entities: [KV],
+    },
+  };
+  constructor(private db: DataSource) {}
+
+  async set(req: SetRequest) {
+    await this.db
+      .createEntityManager()
+      .save(KV, { id: req.key, value: req.value });
+  }
+
+  async get(req: GetRequest): Promise<GetResponse> {
+    let v = await this.db
+      .createQueryBuilder(KV, "kv")
+      .where("kv.id = :id", { id: req.key })
+      .getOne();
+    return { value: v?.value };
+  }
+}
+
+describe("my test", () => {
+  var myService: MyService;
+
+  test("setup", async () => {
+    let namespace = "t_" + nanoid().slice(0, 7);
+    let i = new Injector([MyService]);
+    myService = await i.getInstance("MyService", namespace);
+  });
+
+  test("set get test", async () => {
+    await myService.set({ key: "testkey", value: "testvalue" });
+    let rsp = await myService.get({ key: "testkey" });
+    expect(rsp.value).toBe("testvalue");
+  });
+});
+```
+
+The above tests have the following anatomy:
+
+```ts
+@Entity()
+export class KV {
+  @PrimaryColumn()
+  id?: string;
+
+  @Column()
+  value?: string;
+}
+```
+
+We define the TypeORM database entities our service will handle.
+
+```ts
+interface SetRequest {
+  key?: string;
+  value?: string;
+}
+
+interface GetRequest {
+  key?: string;
+}
+
+interface GetResponse {
+  value?: string;
+}
+```
+
+We define a few interfaces for our endopints. If you look into actual Actio services they are all classes, but here interfaces will do. The difference between the two is that interfaces can't be annotated with reflection hence type information about request and response types can't be extracted. For now we don't care about that.
+
+Let's continue:
+
+```ts
+@Service()
+class MyService {
+  meta = {
+    typeorm: {
+      entities: [KV],
+    },
+  };
+  constructor(private db: DataSource) {}
+```
+
+Here we see two important points. First is that the meta field contains TypeORM settings, namely, the entities we defined is listed here. This is important because Actio sets up the a separate database for each service for namespacing and data isolation purposes, so it needs to know about your entities.
+
+The second important point is accepting the TypeORM `DataSource` type in the constructor parameter. This will make sure Actio will inject it to your service.
+
+```ts
+  async set(req: SetRequest) {
+    await this.db
+      .createEntityManager()
+      .save(KV, { id: req.key, value: req.value });
+  }
+
+  async get(req: GetRequest): Promise<GetResponse> {
+    let v = await this.db
+      .createQueryBuilder(KV, "kv")
+      .where("kv.id = :id", { id: req.key })
+      .getOne();
+    return { value: v?.value };
+  }
+```
+
+Here we do nothing special, just saving and retrieving database entries. Could not be simpler!
+
+Now let's move onto the tests themselves:
+
+```ts
+describe("my test", () => {
+  var myService: MyService;
+
+  test("setup", async () => {
+    let namespace = "t_" + nanoid().slice(0, 7);
+    let i = new Injector([MyService]);
+    myService = await i.getInstance("MyService", namespace);
+  });
+
+  test("set get test", async () => {
+    await myService.set({ key: "testkey", value: "testvalue" });
+    let rsp = await myService.get({ key: "testkey" });
+    expect(rsp.value).toBe("testvalue");
+  });
+});
+```
+
+Perhaps the most important point here is the usage of a random namespace (` let namespace = "t_" + nanoid().slice(0, 7);`). This enables you to run each test in a fresh database. There is no need for setup or teardown. Setup happens automatically.
+
+Teardown is not part of Actio yet, but since every test runs in a fresh database worst case is that you will accumulate databases in your local postgres instance.
+
+Congrats! You just implemented and nicely tested a stateful service that talks to the database!
+
+### 5.2. <a name='Misc'></a>Misc
 
 Running a single test:
 

--- a/examples/example.test.ts
+++ b/examples/example.test.ts
@@ -1,0 +1,67 @@
+import { test, expect, describe } from "@jest/globals";
+import { nanoid } from "nanoid";
+import { Service, Injector } from "@crufters/actio";
+import { DataSource, Entity, PrimaryColumn, Column } from "typeorm";
+
+@Entity()
+export class KV {
+  @PrimaryColumn()
+  id?: string;
+
+  @Column()
+  value?: string;
+}
+
+interface SetRequest {
+  key?: string;
+  value?: string;
+}
+
+interface GetRequest {
+  key?: string;
+}
+
+interface GetResponse {
+  value?: string;
+}
+
+@Service()
+class MyService {
+  meta = {
+    typeorm: {
+      entities: [KV],
+    },
+  };
+  constructor(private db: DataSource) {}
+
+  // this method will be exposed as an HTTP endpoint
+  async set(req: SetRequest) {
+    await this.db
+      .createEntityManager()
+      .save(KV, { id: req.key, value: req.value });
+  }
+
+  async get(req: GetRequest): Promise<GetResponse> {
+    let v = await this.db
+      .createQueryBuilder(KV, "kv")
+      .where("kv.id = :id", { id: req.key })
+      .getOne();
+    return { value: v?.value };
+  }
+}
+
+describe("my test", () => {
+  var myService: MyService;
+
+  test("setup", async () => {
+    let namespace = "t_" + nanoid().slice(0, 7);
+    let i = new Injector([MyService]);
+    myService = await i.getInstance("MyService", namespace);
+  });
+
+  test("set get test", async () => {
+    await myService.set({ key: "testkey", value: "testvalue" });
+    let rsp = await myService.get({ key: "testkey" });
+    expect(rsp.value).toBe("testvalue");
+  });
+});

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@crufters/actio": "^0.2.32",
+        "@crufters/actio": "^0.2.33",
         "@types/express": "^4.17.17",
         "dotenv": "^16.0.3",
         "express": "^4.18.2"
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@crufters/actio": {
-      "version": "0.2.32",
-      "resolved": "https://registry.npmjs.org/@crufters/actio/-/actio-0.2.32.tgz",
-      "integrity": "sha512-VYwp2gRe4Kek+F1RVD/2cJN6ayB+JVybFyEYKkd3QomjDMdAiSkkgIl3KjRd+Skgh11n72HFBrRUOyw14rSj3A==",
+      "version": "0.2.33",
+      "resolved": "https://registry.npmjs.org/@crufters/actio/-/actio-0.2.33.tgz",
+      "integrity": "sha512-CaHMtI99LrvL6NRnGuFrSdUsyOgxyfSjLYcoN1F3JN84gcFtZGurEDAumFJbXhYxLXSvVqoeyvcsq8Pq+f6eOQ==",
       "dependencies": {
         "@google-cloud/storage": "^6.10.1",
         "@sendgrid/mail": "^7.7.0",
@@ -2905,9 +2905,9 @@
       }
     },
     "@crufters/actio": {
-      "version": "0.2.32",
-      "resolved": "https://registry.npmjs.org/@crufters/actio/-/actio-0.2.32.tgz",
-      "integrity": "sha512-VYwp2gRe4Kek+F1RVD/2cJN6ayB+JVybFyEYKkd3QomjDMdAiSkkgIl3KjRd+Skgh11n72HFBrRUOyw14rSj3A==",
+      "version": "0.2.33",
+      "resolved": "https://registry.npmjs.org/@crufters/actio/-/actio-0.2.33.tgz",
+      "integrity": "sha512-CaHMtI99LrvL6NRnGuFrSdUsyOgxyfSjLYcoN1F3JN84gcFtZGurEDAumFJbXhYxLXSvVqoeyvcsq8Pq+f6eOQ==",
       "requires": {
         "@google-cloud/storage": "^6.10.1",
         "@sendgrid/mail": "^7.7.0",

--- a/examples/package.json
+++ b/examples/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@crufters/actio": "^0.2.32",
+    "@crufters/actio": "^0.2.33",
     "@types/express": "^4.17.17",
     "dotenv": "^16.0.3",
     "express": "^4.18.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crufters/actio",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "type": "module",
   "description": "Actio is a lightweight, batteries included Node.js framework for your backend applications.",
   "main": "lib/index.js",

--- a/src/service/authentication/authentication.test.ts
+++ b/src/service/authentication/authentication.test.ts
@@ -34,6 +34,7 @@ describe("auth", () => {
       namespace
     );
 
+    // set config instead of using defaultConfig to test if config is loaded
     await config.configSaveS2S({
       token: "",
       config: {

--- a/src/service/authentication/index.ts
+++ b/src/service/authentication/index.ts
@@ -77,6 +77,7 @@ import {
   FacebookLoginRequest,
   FacebookLoginResponse,
   RegisterOrLoginWithProvenIdentityRequest,
+  defaultConfig,
 } from "./models.js";
 import { ConfigService } from "../config/index.js";
 
@@ -113,12 +114,7 @@ export class AuthenticationService implements Servicelike {
   private facebookAppSecret: string;
   private facebookAppRedirectURL: string;
 
-  defaultConfig: Config = {
-    adminEmail: "example@example.com",
-    adminPassword: "admin",
-    adminOrganization: "Admin Org",
-    fullName: "The Admin",
-  };
+  defaultConfig: Config = defaultConfig;
 
   constructor(connection?: DataSource, config?: ConfigService) {
     this.connection = connection;

--- a/src/service/authentication/models.ts
+++ b/src/service/authentication/models.ts
@@ -57,6 +57,13 @@ export class Config {
   facebookAppRedirectURL?: string;
 }
 
+export const defaultConfig: Config = {
+  adminEmail: "example@example.com",
+  adminPassword: "admin",
+  adminOrganization: "Admin Org",
+  fullName: "The Admin",
+};
+
 // User roles
 @Entity()
 export class Role {

--- a/src/service/authentication/userSave.test.ts
+++ b/src/service/authentication/userSave.test.ts
@@ -2,31 +2,12 @@ import { test, expect, describe } from "@jest/globals";
 import { Injector } from "../../injector.js";
 import { nanoid } from "nanoid";
 import { AuthenticationService } from "./index.js";
-import { ConfigService } from "../config/index.js";
 
 describe("auth user update", () => {
   var auth: AuthenticationService;
 
   test("setup", async () => {
     let namespace = "t_" + nanoid().slice(0, 7);
-    let config: ConfigService = await new Injector([ConfigService]).getInstance(
-      "ConfigService",
-      namespace
-    );
-
-    await config.configSaveS2S({
-      token: "",
-      config: {
-        data: {
-          AuthenticationService: {
-            fullName: "Joey Joe",
-            adminEmail: "test@test.com",
-            adminPassword: "123",
-            adminOrganization: "Your Org",
-          },
-        },
-      },
-    });
 
     let i = new Injector([AuthenticationService]);
     auth = await i.getInstance("AuthenticationService", namespace);

--- a/src/service/payment/payment.test.ts
+++ b/src/service/payment/payment.test.ts
@@ -4,7 +4,6 @@ import { nanoid } from "nanoid";
 import { PaymentService } from "./index.js";
 import { AuthenticationService } from "../authentication/index.js";
 import { UserRegisterResponse } from "../authentication/models.js";
-import { ConfigService } from "../config/index.js";
 import { AccountType, gatewayStripe } from "./models.js";
 // import Stripe from "stripe";
 
@@ -13,24 +12,6 @@ describe("Check balance and payment history", () => {
   var auth: AuthenticationService;
   test("setup", async () => {
     let namespace = "t_" + nanoid().slice(0, 7);
-    let config: ConfigService = await new Injector([ConfigService]).getInstance(
-      "ConfigService",
-      namespace
-    );
-
-    await config.configSaveS2S({
-      token: "",
-      config: {
-        data: {
-          AuthenticationService: {
-            fullName: "Joey Joe",
-            adminEmail: "test@test.com",
-            adminPassword: "123",
-            adminOrganization: "Your Org",
-          },
-        },
-      },
-    });
 
     let i = new Injector([PaymentService]);
     ps = await i.getInstance("PaymentService", namespace);


### PR DESCRIPTION
The auth service registers an admin if there are none at startup.

In tests there are a few ways to get an admin user:
- `auth.tokenAdminGet`
- setting up auth config with with `configSaveS2S` and then logging in with the specified credentials

The latter is a bit wordy so now we export the default credentials in the `auth` models file.